### PR TITLE
Add function to search includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ Helpers for [FHICL](https://cdcvs.fnal.gov/redmine/projects/fhicl/wiki) Files in
  * Helper for moving around included `fcl` files.
      * Defaults to `<Leader>-f` to follow an include, and `Backspace` to return to the previous file.
      * Multiple results are sent to the Location List, where they can be selected with `Enter` to open them.
+ * Helper for finding all `fcl` files that `#include ""` the current one.
+     * Populates the Vim Location List with all the results.
+     * Default to `<Leader>-i`. Then `Enter` to select a file in the Location
+     * List, and `Backspace` to return to the previous file.
  * Update the `commentstring` variable for `.fcl` files, so commenting plugins work.
- * Sets the `JSON` indentation rules for the `.fcl` files, to give more intellingent auto indentation.
+ * Sets the `JSON` indentation rules for the `.fcl` files, to give more intelligent auto indentation.
     * **TODO:** Check and update this logic to make sure it works nicely for all files, and all styles of line.
 
 ### Usage
@@ -60,6 +64,15 @@ let g:vim_fhicl#always_open_first = 0
 " Defaults to 0, set to 1 to never open a file and only populate
 " the location list.
 let g:vim_fhicl#dont_open_file = 0
+
+" The command used to search for files that include the current one.
+" If replaced, the command should be passed with any flags needed for
+" recursive running, as well as only returning files.
+" Defaults to using "grep -lr", where "l" returns just files and "r" makes
+" grep recursive.
+" To use ripgrep, instead use "rg --files".
+let g:vim_fhicl#search_command = "grep -lr"
+
 ```
 
 ### Custom Binds
@@ -72,5 +85,9 @@ nmap <leader>-f <Plug>vim-fhiclFindFhiclFile
 " Remap the swap back function with the following.
 " Replace <BS> with the correct bind.
 nmap <BS> <Plug>vim-fhiclSwapToPrevious
+
+" Remap the search include function with the following.
+" Replace <leader>-i with the correct bind.
+nmap <leader>-i <Plug>vim-fhiclFindIncludes
 
 ```

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -4,6 +4,7 @@ let g:vim_fhicl#search_current = get(g:, 'vim_fhicl#search_current', 0)
 let g:vim_fhicl#search_setting = get(g:, 'vim_fhicl#search_setting', "all")
 let g:vim_fhicl#always_open_first = get(g:, 'vim_fhicl#always_open_first', 0)
 let g:vim_fhicl#dont_open_file = get(g:, 'vim_fhicl#dont_open_file', 0)
+let g:vim_fhicl#search_tool = get(g:, 'vim_fhicl#dont_open_file', "grep")
 
 let s:fhicl_include = '#include \?"\([a-zA-Z0-9/._]\+\)"'
 

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -78,27 +78,9 @@ function! fhicl#base#Find_FHICL_File() abort
         endif
     endfor
 
-    " If the global variable storing the previous link does not exist, make
-    " it. Initialise it to the starter file so that we can always get back to
-    " that no matter what.
-    if !exists('g:vim_fhicl_prev_link')
-        let l:start_file = {}
-        let l:start_file.base_path = l:current_file
+    call fhicl#base#PopulateMovementGlobalsVariables(l:current_file, l:found_fhicl)
 
-        let g:vim_fhicl_prev_link = l:start_file
-    endif
-
-    " Store the current file in a global variable such that it can be used
-    " later to move back to the previous file.
-    " The values are stored in a dict, where the key is the file name and the
-    " value is the parent file. This makes it possible to always navigate
-    " back to the parent file, and also clean up the dict when moving between files.
-    for found_file in l:found_fhicl
-        let l:found_file_short = fnamemodify(found_file, ':t')
-        let g:vim_fhicl_prev_link[l:found_file_short] = l:current_file
-    endfor
-
-    " Now that the previous file is setup, deal with the results:
+    " Now that the file movement is setup, deal with the results:
     "     - If there is only 1 result, open it.
     "       - There is a config option to skip this and only populate the
     "       location list instead.
@@ -214,7 +196,8 @@ function! fhicl#base#Find_FHICL_File() abort
             continue
         endif
 
-        " Actually do the search using grep or ripgrep.
+        " Actually do the search using the user defined tool (usually grep,
+        " though ripgrep is faster).
         " If there is any results, add them to the ongoing list.
         let l:result = systemlist(g:vim_fhicl#search_tool . " " . l:search_term . " " . path)
 
@@ -223,34 +206,10 @@ function! fhicl#base#Find_FHICL_File() abort
         endif
     endfor
 
-    " If the global variable storing the previous link does not exist, make
-    " it. Initialise it to the starter file so that we can always get back to
-    " that no matter what.
-    if !exists('g:vim_fhicl_prev_link')
-        let l:start_file = {}
-        let l:start_file.base_path = l:current_file
+    call fhicl#base#PopulateMovementGlobalsVariables(l:current_file, l:found_includes)
 
-        let g:vim_fhicl_prev_link = l:start_file
-    endif
-
-    " Store the current file in a global variable such that it can be used
-    " later to move back to the previous file.
-    " The values are stored in a dict, where the key is the file name and the
-    " value is the parent file. This makes it possible to always navigate
-    " back to the parent file, and also clean up the dict when moving between files.
-    for found_file in l:found_fhicl
-        let l:found_file_short = fnamemodify(found_file, ':t')
-        let g:vim_fhicl_prev_link[l:found_file_short] = l:current_file
-    endfor
-
-    " Now that the previous file is setup, deal with the results:
-    "     - If there is only 1 result, open it.
-    "       - There is a config option to skip this and only populate the
-    "       location list instead.
-    "     - If there is more than 1, put them in the location list and open the
-    "     list.
-    "       - There is a config option to also open a file in the current
-    "       buffer here too.
+    " Now that the file movement is setup, deal with the results:
+    "     - If there is any results, populate the location list with them.
     "     - If nothing was found, report it and stop.
     if len(l:found_fhicl) > 0
 
@@ -263,6 +222,30 @@ function! fhicl#base#Find_FHICL_File() abort
         return
 
     endif
+
+endfunction
+
+function! fhicl#base#PopulateMovementGlobalsVariables(current_file, file_list) abort
+
+    " If the global variable storing the previous link does not exist, make
+    " it. Initialise it to the starter file so that we can always get back to
+    " that no matter what.
+    if !exists('g:vim_fhicl_prev_link')
+        let l:start_file = {}
+        let l:start_file.base_path = a:current_file
+
+        let g:vim_fhicl_prev_link = l:start_file
+    endif
+
+    " Store the current file in a global variable such that it can be used
+    " later to move back to the previous file.
+    " The values are stored in a dict, where the key is the file name and the
+    " value is the parent file. This makes it possible to always navigate
+    " back to the parent file, and also clean up the dict when moving between files.
+    for found_file in a:file_list
+        let l:found_file_short = fnamemodify(found_file, ':t')
+        let g:vim_fhicl_prev_link[l:found_file_short] = a:current_file
+    endfor
 
 endfunction
 

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -4,7 +4,7 @@ let g:vim_fhicl#search_current = get(g:, 'vim_fhicl#search_current', 0)
 let g:vim_fhicl#search_setting = get(g:, 'vim_fhicl#search_setting', "all")
 let g:vim_fhicl#always_open_first = get(g:, 'vim_fhicl#always_open_first', 0)
 let g:vim_fhicl#dont_open_file = get(g:, 'vim_fhicl#dont_open_file', 0)
-let g:vim_fhicl#search_tool = get(g:, 'vim_fhicl#dont_open_file', "grep")
+let g:vim_fhicl#search_tool = get(g:, 'vim_fhicl#search_tool', "grep")
 
 let s:fhicl_include = '#include \?"\([a-zA-Z0-9/._]\+\)"'
 

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -4,7 +4,7 @@ let g:vim_fhicl#search_current = get(g:, 'vim_fhicl#search_current', 0)
 let g:vim_fhicl#search_setting = get(g:, 'vim_fhicl#search_setting', "all")
 let g:vim_fhicl#always_open_first = get(g:, 'vim_fhicl#always_open_first', 0)
 let g:vim_fhicl#dont_open_file = get(g:, 'vim_fhicl#dont_open_file', 0)
-let g:vim_fhicl#search_tool = get(g:, 'vim_fhicl#search_tool', "grep")
+let g:vim_fhicl#search_command = get(g:, 'vim_fhicl#search_command', "grep -rl")
 
 let s:fhicl_include = '#include \?"\([a-zA-Z0-9/._]\+\)"'
 
@@ -201,7 +201,7 @@ function! fhicl#base#Find_FHICL_Includes() abort
         " Actually do the search using the user defined tool (usually grep,
         " though ripgrep is faster).
         " If there is any results, add them to the ongoing list.
-        let l:result = systemlist(g:vim_fhicl#search_tool . ' "' . l:search_term . '" ' . path)
+        let l:result = systemlist(g:vim_fhicl#search_command . " '" . l:search_term . "' " . path)
 
         if len(l:result) > 0
             let l:found_includes = l:found_includes + l:result

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -48,6 +48,7 @@ function! fhicl#base#Find_FHICL_File() abort
         let l:search_paths = [$MRB_SOURCE] + l:search_paths
     endif
 
+    let l:not_checked_current = 0
     let l:found_fhicl = []
 
     " Search for the file
@@ -60,7 +61,9 @@ function! fhicl#base#Find_FHICL_File() abort
 
         " Skip checking the current working dir if the config option is set.
         " This is to match the functionality of find_fhicl.sh by default.
-        if path == "." && g:vim_fhicl#search_current == 0
+        " Also checks that the current folder hasn't already been checked,
+        " since it can appear multiple times.
+        if path == "." && g:vim_fhicl#search_current == 0 && l:not_checked_current == 0
             continue
         endif
 
@@ -182,6 +185,7 @@ function! fhicl#base#Find_FHICL_Includes() abort
         let l:search_paths = [$MRB_SOURCE] + l:search_paths
     endif
 
+    let l:not_checked_current = 0
     let l:found_includes = []
 
     " Search for the file in other include paths
@@ -194,7 +198,9 @@ function! fhicl#base#Find_FHICL_Includes() abort
 
         " Skip checking the current working dir if the config option is set.
         " This is to match the functionality of find_fhicl.sh by default.
-        if path == "." && g:vim_fhicl#search_current == 0
+        " Also checks that the current folder hasn't already been checked,
+        " since it can appear multiple times.
+        if path == "." && g:vim_fhicl#search_current == 0 && l:not_checked_current == 0
             continue
         endif
 

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -200,8 +200,14 @@ function! fhicl#base#Find_FHICL_Includes() abort
         " This is to match the functionality of find_fhicl.sh by default.
         " Also checks that the current folder hasn't already been checked,
         " since it can appear multiple times.
-        if path == "." && g:vim_fhicl#search_current == 0 && l:not_checked_current == 0
+        if path == "." && g:vim_fhicl#search_current == 0
             continue
+        elseif path == "." && g:vim_fhicl#search_current == 1
+            if l:not_checked_current == 1
+                continue
+            else
+                let l:not_checked_current = 1
+            endif
         endif
 
         " Actually do the search using the user defined tool (usually grep,

--- a/ftplugin/fhicl.vim
+++ b/ftplugin/fhicl.vim
@@ -12,6 +12,12 @@ endif
 nnoremap <silent><buffer> <Plug>vim-fhiclSwapToPrevious :
             \<C-U>call fhicl#base#Swap_To_Previous()<CR>
 
+if !hasmapto('<Plug>vim-fhiclFindIncludes')
+    nmap <silent><buffer> <leader>i <Plug>vim-fhiclFindIncludes
+endif
+nnoremap <silent><buffer> <Plug>vim-fhiclFindIncludes :
+            \<C-U>call fhicl#base#Find_FHICL_Includes()<CR>
+
 " Set the comment string so comment toggling plugins work properly.
 setlocal commentstring=#\ %s
 


### PR DESCRIPTION
This PR adds a function that searches for all `fcl` files that include the current file.

That is, when inside `services_dune.fcl`, the function will search for all files in every folder defined in the `$FHICL_FILE_PATH` that contains `#include "services_dune.fcl"`, using `grep` (or a user defined command, so I can use `ripgrep`). The results are then populated into a location list.

This is bound to `<leader>-i` by default.