### PR TITLE
Search all FHICL file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Helpers for [FHICL](https://cdcvs.fnal.gov/redmine/projects/fhicl/wiki) Files in
     * Highlight keywords like `physics`, `analyzers` to flag up typos.
     * Properly colour `#include` statements, comments and numbers.
  * Helper for moving around included `fcl` files.
-     * Defaults to `<Leader>-f` to follow an include, and `Backspace` to return to the previous file.
+     * Defaults to `<Leader>-ff` to follow an include, and `Backspace` to return to the previous file.
      * Multiple results are sent to the Location List, where they can be selected with `Enter` to open them.
  * Helper for finding all `fcl` files that `#include ""` the current one.
      * Populates the Vim Location List with all the results.
-     * Default to `<Leader>-i`. Then `Enter` to select a file in the Location
+     * Default to `<Leader>-fi`. Then `Enter` to select a file in the Location
      * List, and `Backspace` to return to the previous file.
      * Uses `grep` by default, but can be changed to any other command.
  * Helper for finding all `fcl` files in the current path.
+     * Defaults to `<Leader>-fs`.
      * Results are pasted into the location list, or piped into `FZF` if available.
         * `fzf`: https://github.com/junegunn/fzf.vim
  * Update the `commentstring` variable for `.fcl` files, so commenting plugins work.
@@ -77,21 +78,32 @@ let g:vim_fhicl#dont_open_file = 0
 " To use ripgrep, instead use "rg --files".
 let g:vim_fhicl#search_command = "grep -lr"
 
+" The command used to find files.
+" If replaced, the command should be passed with any flags needed for
+" recursive running, as well as only returning files.
+" Defaults to using "find", and due to the command setup, only find
+" replacements will work easily. Code could be updated to instead take a full
+" command, not just an executable.
+let g:vim_fhicl#find_command = "find"
 ```
 
 ### Custom Binds
 
 ```vim
 " Remap the follow function with the following.
-" Replace <leader>-f with the correct bind.
-nmap <leader>-f <Plug>vim-fhiclFindFhiclFile
+" Replace <leader>-ff with the correct bind.
+nmap <leader>-ff <Plug>vim-fhiclFindFhiclFile
 
 " Remap the swap back function with the following.
 " Replace <BS> with the correct bind.
 nmap <BS> <Plug>vim-fhiclSwapToPrevious
 
 " Remap the search include function with the following.
-" Replace <leader>-i with the correct bind.
-nmap <leader>-i <Plug>vim-fhiclFindIncludes
+" Replace <leader>-fi with the correct bind.
+nmap <leader>-fi <Plug>vim-fhiclFindIncludes
+
+" Remap the search through all file names with the following.
+" Replace <leader>-fi with the correct bind.
+nmap <leader>-fi <Plug>vim-fhiclFindAll
 
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Helpers for [FHICL](https://cdcvs.fnal.gov/redmine/projects/fhicl/wiki) Files in
      * Populates the Vim Location List with all the results.
      * Default to `<Leader>-i`. Then `Enter` to select a file in the Location
      * List, and `Backspace` to return to the previous file.
+     * Uses `grep` by default, but can be changed to any other command.
+ * Helper for finding all `fcl` files in the current path.
+     * Results are pasted into the location list, or piped into `FZF` if available.
+        * `fzf`: https://github.com/junegunn/fzf.vim
  * Update the `commentstring` variable for `.fcl` files, so commenting plugins work.
  * Sets the `JSON` indentation rules for the `.fcl` files, to give more intelligent auto indentation.
     * **TODO:** Check and update this logic to make sure it works nicely for all files, and all styles of line.

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -216,6 +216,7 @@ function! fhicl#base#Find_All_FHICL() abort
         return
     endif
 
+    let l:current_file_path = expand('%:p')
     let l:search_paths = fhicl#base#Get_Search_Paths()
 
     let l:found_fhicl = []
@@ -236,18 +237,21 @@ function! fhicl#base#Find_All_FHICL() abort
 
         " Actually do the search using the user defined tool (usually find).
         " If there is any results, add them to the ongoing list.
-        let l:result = systemlist(g:vim_fhicl#find_command . " " . path . " -name *.fcl")
+        let l:result = systemlist(g:vim_fhicl#find_command . ' ' . path . ' -name "*.fcl"')
 
         if len(l:result) > 0
             let l:found_fhicl = l:found_fhicl + l:result
         endif
     endfor
 
+    call fhicl#base#PopulateMovementGlobalsVariables(l:current_file_path, l:found_includes)
+
     " Now that the file movement is setup, deal with the results:
     "     - If there is any results, populate the location list with them.
     "     - If nothing was found, report it and stop.
     if len(l:found_fhicl) > 0 && exists("g:fzf#vim#buffers") == 1
-        call fzf#run(fzf#wrap({'source': l:found_fhicl, 'options': '-d "/" --with-nth="-1"'}))
+        call fzf#run(fzf#wrap({'source': l:found_fhicl, 
+                    \ 'options': '-d "/" --with-nth="-1" --preview "head -100 {}"'}))
     elseif len(l:found_fhicl) > 0 && exists("g:fzf#vim#buffers") == 0
         call setloclist(0, map(l:found_fhicl, '{"filename": v:val}'))
         lopen

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -5,7 +5,7 @@ let g:vim_fhicl#search_setting = get(g:, 'vim_fhicl#search_setting', "all")
 let g:vim_fhicl#always_open_first = get(g:, 'vim_fhicl#always_open_first', 0)
 let g:vim_fhicl#dont_open_file = get(g:, 'vim_fhicl#dont_open_file', 0)
 let g:vim_fhicl#search_command = get(g:, 'vim_fhicl#search_command', "grep -rl")
-let g:vim_fhicl#find_command = get(g:, 'vim_fhicl#find_command', "grep -rl")
+let g:vim_fhicl#find_command = get(g:, 'vim_fhicl#find_command', "find")
 
 let s:fhicl_include = '#include \?"\([a-zA-Z0-9/._]\+\)"'
 
@@ -236,7 +236,7 @@ function! fhicl#base#Find_All_FHICL() abort
 
         " Actually do the search using the user defined tool (usually find).
         " If there is any results, add them to the ongoing list.
-        let l:result = systemlist(g:vim_fhicl#find_command . " " . path . " *.fcl")
+        let l:result = systemlist(g:vim_fhicl#find_command . " " . path . " -name *.fcl")
 
         if len(l:result) > 0
             let l:found_fhicl = l:found_fhicl + l:result
@@ -247,7 +247,7 @@ function! fhicl#base#Find_All_FHICL() abort
     "     - If there is any results, populate the location list with them.
     "     - If nothing was found, report it and stop.
     if len(l:found_fhicl) > 0 && exists("g:fzf#vim#buffers") == 1
-        let g:test_fhicl = l:found_fhicl
+        call fzf#run(fzf#wrap({'source': l:found_fhicl, 'options': '-d "/" --with-nth="-1"'}))
     elseif len(l:found_fhicl) > 0 && exists("g:fzf#vim#buffers") == 0
         call setloclist(0, map(l:found_fhicl, '{"filename": v:val}'))
         lopen

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -5,6 +5,7 @@ let g:vim_fhicl#search_setting = get(g:, 'vim_fhicl#search_setting', "all")
 let g:vim_fhicl#always_open_first = get(g:, 'vim_fhicl#always_open_first', 0)
 let g:vim_fhicl#dont_open_file = get(g:, 'vim_fhicl#dont_open_file', 0)
 let g:vim_fhicl#search_command = get(g:, 'vim_fhicl#search_command', "grep -rl")
+let g:vim_fhicl#find_command = get(g:, 'vim_fhicl#find_command', "grep -rl")
 
 let s:fhicl_include = '#include \?"\([a-zA-Z0-9/._]\+\)"'
 
@@ -41,21 +42,7 @@ function! fhicl#base#Find_FHICL_File() abort
 
     " Get the file to look for, and setup the search paths.
     let l:fhicl_file = split(l:match_list[1], "/")[-1]
-    let l:search_paths = split($FHICL_FILE_PATH, ":")
-
-    " If a local sources folder exists, use that.
-    " Add to the front since to favour a local, editable copy.
-    if exists($MRB_SOURCE)
-        let l:search_paths = [$MRB_SOURCE] + l:search_paths
-    endif
-
-    " If we should search the current directory, add it.
-    if (g:vim_fhicl#search_current == 1)
-        let l:search_paths = [l:current_abs_path] + l:search_paths
-    endif
-
-    " Remove any duplicates
-    let l:search_paths = fhicl#base#Remove_Path_Dupes(l:search_paths)
+    let l:search_paths = fhicl#base#Get_Search_Paths()
 
     let l:found_fhicl = []
 
@@ -100,28 +87,22 @@ function! fhicl#base#Find_FHICL_File() abort
     "       buffer here too.
     "     - If nothing was found, report it and stop.
     if len(l:found_fhicl) == 1
-
         if g:vim_fhicl#dont_open_file
             call setloclist(0, map(l:found_fhicl, '{"filename": v:val}'))
             lopen
         else
             execute "edit " . l:found_fhicl[0]
         endif
-
     elseif len(l:found_fhicl) > 1
-
         if g:vim_fhicl#always_open_first && !g:vim_fhicl#dont_open_file
             execute "edit " . l:found_fhicl[0]
         endif
 
         call setloclist(0, map(l:found_fhicl, '{"filename": v:val}'))
         lopen
-
     elseif len(l:found_fhicl) == 0
-
         call EchoWarning("No matches found...")
         return
-
     endif
 
 endfunction
@@ -180,26 +161,10 @@ function! fhicl#base#Find_FHICL_Includes() abort
     " Get the current file path to search for.
     let l:current_file_path = expand('%:p')
     let l:current_file = expand('%:t')
-    let l:current_abs_path = expand('%:p:h')
 
     " Make the search term (i.e. the include line) and the search paths.
     let l:search_term = '#include "' . l:current_file . '"'
-    let l:search_paths = split($FHICL_FILE_PATH, ":")
-
-    " If a local sources folder exists, use that.
-    " Add to the front since to favour a local, editable copy.
-    if exists($MRB_SOURCE)
-        let l:search_paths = [$MRB_SOURCE] + l:search_paths
-    endif
-
-    " If we should search the current directory, add it.
-    if (g:vim_fhicl#search_current == 1)
-        let l:search_paths = [l:current_abs_path] + l:search_paths
-    endif
-
-    " Remove any duplicates
-    let l:search_paths = fhicl#base#Remove_Path_Dupes(l:search_paths)
-
+    let l:search_paths = fhicl#base#Get_Search_Paths()
 
     let l:found_includes = []
 
@@ -233,15 +198,62 @@ function! fhicl#base#Find_FHICL_Includes() abort
     "     - If there is any results, populate the location list with them.
     "     - If nothing was found, report it and stop.
     if len(l:found_includes) > 0
-
         call setloclist(0, map(l:found_includes, '{"filename": v:val}'))
         lopen
-
     elseif len(l:found_includes) == 0
-
         call EchoWarning("No matches found...")
         return
+    endif
 
+endfunction
+
+" Function to list all FHICL files that are in the FHICL_FILE_PATH.
+function! fhicl#base#Find_All_FHICL() abort
+
+    " If the env var isn't set, stop.
+    if empty($FHICL_FILE_PATH)
+        call EchoWarning("$FHICL_FILE_PATH isn't set!")
+        return
+    endif
+
+    let l:search_paths = fhicl#base#Get_Search_Paths()
+
+    let l:found_fhicl = []
+
+    " Search for the file in other include paths
+    for path in l:search_paths
+
+        " If the folder doesn't exist, don't bother searching there.
+        if !isdirectory(path)
+            continue
+        endif
+
+        " Skip checking the current working directory, since if needed it will
+        " have already been added.
+        if path == "."
+            continue
+        endif
+
+        " Actually do the search using the user defined tool (usually find).
+        " If there is any results, add them to the ongoing list.
+        let l:result = systemlist(g:vim_fhicl#find_command . " " . path . " *.fcl")
+
+        if len(l:result) > 0
+            let l:found_fhicl = l:found_fhicl + l:result
+        endif
+    endfor
+
+    " Now that the file movement is setup, deal with the results:
+    "     - If there is any results, populate the location list with them.
+    "     - If nothing was found, report it and stop.
+    if len(l:found_fhicl) > 0 && exists("g:fzf#vim#buffers") == 1
+        let g:test_fhicl = l:found_fhicl
+    elseif len(l:found_fhicl) > 0 && exists("g:fzf#vim#buffers") == 0
+        call setloclist(0, map(l:found_fhicl, '{"filename": v:val}'))
+        lopen
+    elseif len(l:found_fhicl) == 0
+        call EchoWarning("No matches found...")
+        return
     endif
 
 endfunction
@@ -269,6 +281,28 @@ function! fhicl#base#PopulateMovementGlobalsVariables(current_file, file_list) a
         let l:found_file_short = fnamemodify(found_file, ':t')
         let g:vim_fhicl_prev_link[l:found_file_short] = a:current_file
     endfor
+
+endfunction
+
+" Helper function to get the FHICL search path.
+function! fhicl#base#Get_Search_Paths() abort
+
+    let l:search_paths = split($FHICL_FILE_PATH, ":")
+    let l:current_abs_path = expand('%:p:h')
+
+    " If a local sources folder exists, use that.
+    " Add to the front since to favour a local, editable copy.
+    if exists($MRB_SOURCE)
+        let l:search_paths = [$MRB_SOURCE] + l:search_paths
+    endif
+
+    " If we should search the current directory, add it.
+    if (g:vim_fhicl#search_current == 1)
+        let l:search_paths = [l:current_abs_path] + l:search_paths
+    endif
+
+    " Remove any duplicates
+    return fhicl#base#Remove_Path_Dupes(l:search_paths)
 
 endfunction
 

--- a/autoload/fhicl/base.vim
+++ b/autoload/fhicl/base.vim
@@ -244,7 +244,7 @@ function! fhicl#base#Find_All_FHICL() abort
         endif
     endfor
 
-    call fhicl#base#PopulateMovementGlobalsVariables(l:current_file_path, l:found_includes)
+    call fhicl#base#PopulateMovementGlobalsVariables(l:current_file_path, l:found_fhicl)
 
     " Now that the file movement is setup, deal with the results:
     "     - If there is any results, populate the location list with them.

--- a/ftplugin/fhicl.vim
+++ b/ftplugin/fhicl.vim
@@ -1,7 +1,7 @@
 " FHICL Default Bindings
 
 if !hasmapto('<Plug>vim-fhiclFindFhiclFile')
-    nmap <silent><buffer> <leader>f <Plug>vim-fhiclFindFhiclFile
+    nmap <silent><buffer> <leader>ff <Plug>vim-fhiclFindFhiclFile
 endif
 nnoremap <silent><buffer> <Plug>vim-fhiclFindFhiclFile :
             \<C-U>call fhicl#base#Find_FHICL_File()<CR>
@@ -13,10 +13,16 @@ nnoremap <silent><buffer> <Plug>vim-fhiclSwapToPrevious :
             \<C-U>call fhicl#base#Swap_To_Previous()<CR>
 
 if !hasmapto('<Plug>vim-fhiclFindIncludes')
-    nmap <silent><buffer> <leader>i <Plug>vim-fhiclFindIncludes
+    nmap <silent><buffer> <leader>fi <Plug>vim-fhiclFindIncludes
 endif
 nnoremap <silent><buffer> <Plug>vim-fhiclFindIncludes :
             \<C-U>call fhicl#base#Find_FHICL_Includes()<CR>
+
+if !hasmapto('<Plug>vim-fhic()lFindAll')
+    nmap <silent><buffer> <leader>fs <Plug>vim-fhic()lFindAll
+endif
+nnoremap <silent><buffer> <Plug>vim-fhiclFindAll :
+            \<C-U>call fhicl#base#Find_All_FHICL()<CR>
 
 " Set the comment string so comment toggling plugins work properly.
 setlocal commentstring=#\ %s

--- a/ftplugin/fhicl.vim
+++ b/ftplugin/fhicl.vim
@@ -18,8 +18,8 @@ endif
 nnoremap <silent><buffer> <Plug>vim-fhiclFindIncludes :
             \<C-U>call fhicl#base#Find_FHICL_Includes()<CR>
 
-if !hasmapto('<Plug>vim-fhic()lFindAll')
-    nmap <silent><buffer> <leader>fs <Plug>vim-fhic()lFindAll
+if !hasmapto('<Plug>vim-fhiclFindAll')
+    nmap <silent><buffer> <leader>fs <Plug>vim-fhiclFindAll
 endif
 nnoremap <silent><buffer> <Plug>vim-fhiclFindAll :
             \<C-U>call fhicl#base#Find_All_FHICL()<CR>


### PR DESCRIPTION
Add a command to search through all `fcl` file names.

When the user has `fzf` installed, give an interactive prompt with preview of the file. If they don't, instead populate the location list with the location of every file, which can then be looked through and searched like any other buffer.